### PR TITLE
Fix overflowed text by ellipses and fold style

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,0 +1,12 @@
+.ellipsisable-text {
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.foldable-text
+{
+    word-wrap: break-word;
+    overflow-wrap: break-word;
+}

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -4,11 +4,10 @@
     <%= image_tag game.icon.url, class: 'game-icon-image' %>
   </div>
   <div class="row">
-    <div class="col-xs-10  col-xs-offset-1">
-
+    <div class="col-xs-10 col-xs-offset-1">
       <!-- Start of the content -->
       <div class="post-content--front-page">
-        <h1 class="front-page-title">
+        <h1 class="front-page-title ellipsisable-text">
           <%= link_to game.title, game_path(game) %>
         </h1>
         <p>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,14 +5,14 @@
         <%= image_tag @game.icon.url, class: 'img-responsive' %>
       </div>
       <div class="col-sm-6 col-md-7 col-lg-8">
-        <h1><%= @game.title %></h1>
+        <h1 class="foldable-text"><%= @game.title %></h1>
         <h2>
           <span class="label <%= @game.permission ? 'label-primary' : 'label-danger' %>">
               <%= @game.permission ? '実況OK' : '実況NG' %>
           </span>
         </h2>
         <% if @game.specific_conditions.present? %>
-            <p><%= @game.specific_conditions %></p>
+            <p class="foldable-text"><%= @game.specific_conditions %></p>
         <% end %>
         <% if @game.android_url.present? %>
           <%= link_to @game.android_url, target: '_blank' do %>


### PR DESCRIPTION
* ゲーム一覧画面のタイトルを横幅からはみ出る場合に省略するようにしました。
* ゲーム詳細画面のタイトルと説明文がはみ出る場合に折り返すようにしました。