### PR TITLE
fix #48 remove game permission

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,8 +39,6 @@ jobs:
       # Database setup
       - run: bundle exec rake db:create RAILS_ENV=test
       - run: bundle exec rake db:schema:load RAILS_ENV=test
-      - run: bundle exec rake db:migrate RAILS_ENV=test
-      - run: bundle exec rake db:seed RAILS_ENV=test
 
       # run tests!
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,7 @@ jobs:
       - run: bundle exec rake db:create RAILS_ENV=test
       - run: bundle exec rake db:schema:load RAILS_ENV=test
       - run: bundle exec rake db:migrate RAILS_ENV=test
+      - run: bundle exec rake db:seed RAILS_ENV=test
 
       # run tests!
       - run:

--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -5,12 +5,7 @@ module Api
     def index
 
       pp params
-      games = Game.select(:id, :title, :icon, :permission, :android_url, :ios_url)
-
-      # unless params[:permission].blank?
-      #   p = params[:permission] == "true"
-      #   games = games.where(permission: p)
-      # end
+      games = Game.select(:id, :title, :icon, :android_url, :ios_url)
 
       unless params[:category].blank?
         games = games.where(category_id: params[:category])

--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -7,11 +7,10 @@ module Api
       pp params
       games = Game.select(:id, :title, :icon, :permission, :android_url, :ios_url)
 
-      unless params[:permission].blank?
-        p = params[:permission] == "true"
-        games = games.where(permission: p)
-      end
-
+      # unless params[:permission].blank?
+      #   p = params[:permission] == "true"
+      #   games = games.where(permission: p)
+      # end
 
       unless params[:category].blank?
         games = games.where(category_id: params[:category])

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -26,7 +26,7 @@
             <div class="form-group">
               <label for="game_category" class="col-lg-3 control-label">ジャンル</label>
               <div class="col-lg-9">
-                <%= form.select :category_id, @categories.map {|c| [c.name, c.id]}, {include_blank: '選択してください'}, {class: 'form-control'} %>
+                <%= form.select :category_id, @categories.map {|c| [c.name, c.id]}, {include_blank: '選択してください'}, {id: 'game_category', class: 'form-control'} %>
               </div>
             </div>
 
@@ -79,7 +79,7 @@
                   </div>
                 </div>
 
-          <% end %>
+            <% end %>
 
             <div class="form-group">
               <div class="col-lg-9 col-lg-offset-3">

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -31,17 +31,6 @@
             </div>
 
             <div class="form-group">
-              <label for="game_permission" class="col-lg-3 control-label">実況可否</label>
-              <div class="col-lg-9">
-                <label class="checkbox">
-                  <label>
-                    <%= form.check_box :permission, id: :game_permission %> 実況OK
-                  </label>
-                </label>
-              </div>
-            </div>
-
-            <div class="form-group">
               <label for="game_specific_conditions" class="col-lg-3 control-label">条件・要望</label>
               <div class="col-lg-9">
                 <%= form.text_area :specific_conditions, id: :game_specific_conditions, class: 'form-control', placeholder: '実況に際して条件・要望があればこちらに。' %>

--- a/app/views/games/_game.html.erb
+++ b/app/views/games/_game.html.erb
@@ -11,7 +11,6 @@
           <%= link_to game.title, game_path(game) %>
         </div>
         <p>
-          <span class="label <%= game.permission ? 'label-primary' : 'label-danger' %>"><%= game.permission ? '実況OK' : '実況NG' %></span>
           <% if game.android_url.present? then %>
               <span class="label label-default">Android</span>
           <% end %>

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -6,11 +6,6 @@
       </div>
       <div class="col-sm-6 col-md-7 col-lg-8">
         <h1 class="foldable-text"><%= @game.title %></h1>
-        <h2>
-          <span class="label <%= @game.permission ? 'label-primary' : 'label-danger' %>">
-              <%= @game.permission ? '実況OK' : '実況NG' %>
-          </span>
-        </h2>
         <% if @game.specific_conditions.present? %>
             <p class="foldable-text"><%= @game.specific_conditions %></p>
         <% end %>

--- a/db/migrate/20171213131014_remove_permission_from_users.rb
+++ b/db/migrate/20171213131014_remove_permission_from_users.rb
@@ -1,0 +1,9 @@
+class RemovePermissionFromUsers < ActiveRecord::Migration[5.1]
+  def up
+    remove_column :games, :permission
+  end
+
+  def down
+    add_column :games, :permission, null: false, default: '0'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171202050948) do
+ActiveRecord::Schema.define(version: 20171213131014) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -20,7 +20,6 @@ ActiveRecord::Schema.define(version: 20171202050948) do
 
   create_table "games", force: :cascade do |t|
     t.string "title", default: "", null: false
-    t.boolean "permission", default: false, null: false
     t.string "specific_conditions"
     t.string "android_url"
     t.string "ios_url"

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -1,9 +1,11 @@
 FactoryBot.define do
   factory :game do
     title {Faker::App.name}
-    permission {Faker::Boolean.boolean}
     specific_conditions {Faker::Lorem.sentence}
     android_url {['', Faker::Internet.url('example.com')].sample(1).first}
     ios_url {['', Faker::Internet.url('example.com')].sample(1).first}
+
+    user
+    category
   end
 end

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -30,14 +30,16 @@ feature "Game Registeration" do
   end
 
   scenario "ゲーム一覧" do
-    create(:game)
-    create(:game)
-    create(:game)
-    create(:game)
-    create(:game)
+    game1 = create(:game)
+    game2 = create(:game)
+    game3 = create(:game)
 
     # アクセスできること
     visit games_path
+
+    expect(page).to have_link  game1.title
+    expect(page).to have_link  game2.title
+    expect(page).to have_link  game3.title
   end
 
   scenario "ゲーム詳細" do

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 feature "Game Registeration" do
 
   background do
+    create(:category, name: 'シューティング')
+    create(:category, name: 'アクション')
+    create(:category, name: 'アドベンチャー')
+
     user = build(:user)
     user.skip_confirmation!
     user.save

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+feature "Game Registeration" do
+
+  background do
+    user = build(:user)
+    user.skip_confirmation!
+    user.save
+    sign_in user
+  end
+
+  scenario "ゲームを登録" do
+    visit root_path
+    click_link 'ゲームを登録'
+    expect(page).to have_text "新規登録"
+
+    fill_in 'タイトル', with: 'これはゲームタイトルです。'
+    select "シューティング", from: "game_category"
+    check "game_permission"
+    fill_in '条件・要望', with: 'ダウンロードページへのリンクを貼ってね！！！'
+    fill_in 'AndroidストアURL', with: 'https://google.com/hogehoge'
+    fill_in 'iOSストアURL', with: 'https://google.com/fugafuga'
+
+    click_button '作成'
+
+    expect(page).to have_text 'これはゲームタイトルです'
+  end
+end

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -16,7 +16,6 @@ feature "Game Registeration" do
 
     fill_in 'タイトル', with: 'これはゲームタイトルです。'
     select "シューティング", from: "game_category"
-    check "game_permission"
     fill_in '条件・要望', with: 'ダウンロードページへのリンクを貼ってね！！！'
     fill_in 'AndroidストアURL', with: 'https://google.com/hogehoge'
     fill_in 'iOSストアURL', with: 'https://google.com/fugafuga'
@@ -24,5 +23,23 @@ feature "Game Registeration" do
     click_button '作成'
 
     expect(page).to have_text 'これはゲームタイトルです'
+  end
+
+  scenario "ゲーム一覧" do
+    create(:game)
+    create(:game)
+    create(:game)
+    create(:game)
+    create(:game)
+
+    # アクセスできること
+    visit games_path
+  end
+
+  scenario "ゲーム詳細" do
+    game = create(:game)
+
+    # アクセスできること
+    visit game_path(id: game.id)
   end
 end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -1,0 +1,28 @@
+require 'rails_helper'
+
+describe Game do
+  describe "ファクトリ" do
+    it "通常ゲーム" do
+      game = build(:game)
+      expect(game).to be_valid
+    end
+  end
+
+  describe "バリデーション" do
+    describe ":title" do
+      let(:game) {build(:game, title: title)}
+      subject {game}
+
+      context "空白の場合" do
+        let(:title) {"    "}
+        it {is_expected.not_to be_valid}
+      end
+
+      context "65文字以上の場合" do
+        let(:title) {"a" * 65}
+        it {is_expected.not_to be_valid}
+      end
+    end
+  end
+
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -58,4 +58,5 @@ RSpec.configure do |config|
   # devise
   config.include Devise::Test::ControllerHelpers, type: :controller
   config.include Devise::Test::ControllerHelpers, type: :view
+  config.include Devise::Test::IntegrationHelpers, type: :feature
 end


### PR DESCRIPTION
ゲームモデルから実況OK/NG(:permission)を削除しました。

未リリースの検索ページ( `/games2` )でもこの項目を使ってるが、 @Subarunari さん触ってる箇所だと思うので放置しました。 （viewだけの問題なので適当なタイミングで削除）

staging,productionへのリリース時に `rake db:migrate` 必要。
