### PR TITLE
fix #47 add guideline to games

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -90,7 +90,7 @@ class GamesController < ApplicationController
   # Confirms the correct user.
   def correct_user
     if @game.user != current_user
-      redirect_to(root_url)
+      render template: "errors/forbidden", layout: false, status: :forbidden
     end
   end
 end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -84,7 +84,7 @@ class GamesController < ApplicationController
 
   # Never trust parameters from the scary internet, only allow the white list through.
   def game_params
-    params.require(:game).permit(:title, :permission, :specific_conditions, :android_url, :ios_url, :icon, :category_id)
+    params.require(:game).permit(:title, :permission, :specific_conditions, :android_url, :ios_url, :icon, :category_id, :guideline)
   end
 
   # Confirms the correct user.

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -3,6 +3,7 @@ class Game < ApplicationRecord
   belongs_to :category
 
   validates :title, presence: true, length: {maximum: 64}
+  validates :guideline, length: {maximum: 512}
 
   mount_uploader :icon, IconUploader
 

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -31,13 +31,6 @@
             </div>
 
             <div class="form-group">
-              <label for="game_specific_conditions" class="col-lg-3 control-label">条件・要望</label>
-              <div class="col-lg-9">
-                <%= form.text_area :specific_conditions, id: :game_specific_conditions, class: 'form-control', placeholder: '実況に際して条件・要望があればこちらに。' %>
-              </div>
-            </div>
-
-            <div class="form-group">
               <label for="game_android_url" class="col-lg-3 control-label">AndroidストアURL</label>
               <div class="col-lg-9">
                 <%= form.text_field :android_url, id: :game_android_url, class: 'form-control', placeholder: 'https://play.google.com/store/apps/details?id=[パッケージ名]' %>
@@ -48,6 +41,20 @@
               <label for="game_ios_url" class="col-lg-3 control-label">iOSストアURL</label>
               <div class="col-lg-9">
                 <%= form.text_field :ios_url, id: :game_ios_url, class: 'form-control', placeholder: 'https://itunes.apple.com/jp/app/id[app_id]' %>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="game_guideline" class="col-lg-3 control-label">ガイドライン</label>
+              <div class="col-lg-9">
+                <%= form.text_area :guideline, id: :game_guideline, class: 'form-control', rows: 5, placeholder: '実況に関するガイドライン、もしくはガイドラインを記載したURLがあれば入力してください。特にない場合は何も記入しないでください。' %>
+              </div>
+            </div>
+
+            <div class="form-group">
+              <label for="game_specific_conditions" class="col-lg-3 control-label">実況者へ伝えたいこと</label>
+              <div class="col-lg-9">
+                <%= form.text_area :specific_conditions, id: :game_specific_conditions, class: 'form-control', rows: 3, placeholder: 'ゲームの楽しみ方など、実況者へ伝えたいことがあれば入力してください。' %>
               </div>
             </div>
 

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -5,7 +5,11 @@
         <%= image_tag @game.icon.url, class: 'img-responsive' %>
       </div>
       <div class="col-sm-6 col-md-7 col-lg-8">
+        <p><%= @game.category.name %></p>
         <h1 class="foldable-text"><%= @game.title %></h1>
+        <% if @game.guideline.present? %>
+            <p class="foldable-text"><%= @game.guideline %></p>
+        <% end %>
         <% if @game.specific_conditions.present? %>
             <p class="foldable-text"><%= @game.specific_conditions %></p>
         <% end %>

--- a/db/migrate/20171213131014_remove_permission_from_users.rb
+++ b/db/migrate/20171213131014_remove_permission_from_users.rb
@@ -4,6 +4,6 @@ class RemovePermissionFromUsers < ActiveRecord::Migration[5.1]
   end
 
   def down
-    add_column :games, :permission, null: false, default: '0'
+    add_column :games, :permission, :boolean, null: false, default: '0'
   end
 end

--- a/db/migrate/20171213141732_add_guideline_to_games.rb
+++ b/db/migrate/20171213141732_add_guideline_to_games.rb
@@ -1,0 +1,5 @@
+class AddGuidelineToGames < ActiveRecord::Migration[5.1]
+  def change
+    add_column :games, :guideline, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171213131014) do
+ActiveRecord::Schema.define(version: 20171213141732) do
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 20171213131014) do
     t.string "image3"
     t.string "image4"
     t.string "image5"
+    t.text "guideline"
   end
 
   create_table "social_profiles", force: :cascade do |t|

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -1,0 +1,307 @@
+require 'rails_helper'
+
+describe GamesController do
+
+  shared_examples 'ログイン不要なアクセス' do
+    describe "GET #index" do
+      before do
+        @game1 = create(:game)
+        @game2 = create(:game)
+        @game3 = create(:game)
+        get :index
+      end
+
+      it 'returns a success response' do
+        expect(response).to be_success
+      end
+
+      it 'assigns all games' do
+        expect(assigns(:games)).to include @game1, @game2, @game3
+      end
+    end
+
+    describe "GET #show" do
+      before do
+        @game = create(:game)
+      end
+      context '存在する場合' do
+        before do
+          get :show, params: {id: @game.id}
+        end
+        it 'returns a success response' do
+          expect(response).to be_success
+        end
+        it 'assigns game' do
+          expect(assigns(:game)).to eq @game
+        end
+        it 'displays show template' do
+          expect(response).to render_template :show
+        end
+      end
+      context '存在しない場合' do
+        it 'raise RecordNotFound' do
+          expect {
+            get :show, params: {id: 12345}
+          }.to raise_exception(ActiveRecord::RecordNotFound)
+        end
+      end
+
+    end
+  end
+
+  shared_examples '非ログインのアクセス' do
+
+    describe "GET #new" do
+      before do
+        get :new
+      end
+      it 'ログイン画面にリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "GET #edit" do
+      before do
+        @game = create(:game)
+        get :edit, params: {id: @game.id}
+      end
+      it 'ログイン画面にリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "POST #create" do
+      before do
+        post :create, params: {game: build(:game).attributes}
+      end
+      it 'ログイン画面にリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "PUT #update" do
+      before do
+        create(:game)
+        create(:game)
+        @game = create(:game)
+        put :update, params: {id: @game.id, game: @game.attributes}
+      end
+      it 'ログイン画面にリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+
+    describe "DELETE #destroy" do
+      before do
+        @game = create(:game)
+        delete :destroy, params: {id: @game.id}
+      end
+      it 'ログイン画面にリダイレクトされること' do
+        expect(response).to redirect_to new_user_session_path
+      end
+    end
+  end
+
+  shared_examples '一般ユーザーのアクセス' do
+
+    describe "GET #new" do
+      before do
+        get :new
+      end
+      it "returns a success response" do
+        expect(response).to be_success
+      end
+      it "assigns new game" do
+        expect(assigns(:game)).to be_a_new(Game)
+      end
+    end
+
+    describe "POST #create" do
+      context "with valid params" do
+        it "creates a new Game" do
+          expect {
+            post :create, params: {game: build(:game).attributes}
+          }.to change(Game, :count).by(1)
+        end
+
+        it "redirects to the created game" do
+          post :create, params: {game: build(:game).attributes}
+          expect(response).to redirect_to(Game.last)
+        end
+      end
+
+      context "with invalid params" do
+        it "returns a success response (i.e. to display the 'new' template)" do
+          post :create, params: {game: build(:invalid_game).attributes}
+          expect(response).to be_success
+        end
+      end
+    end
+
+    describe "自分のゲーム" do
+      before do
+        create(:game)
+        @game = create(:game, user: @logged_in_user)
+        create(:game)
+      end
+
+      describe "GET #edit" do
+        context '存在する場合' do
+          before do
+            get :edit, params: {id: @game.id}
+          end
+          it 'returns a success response' do
+            expect(response).to be_success
+          end
+          it 'assigns game' do
+            expect(assigns(:game)).to eq @game
+          end
+          it 'displays edit template' do
+            expect(response).to render_template :edit
+          end
+        end
+        context '存在しない場合' do
+          it 'raise RecordNotFound' do
+            expect {
+              get :edit, params: {id: 12345}
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      describe "PUT #update" do
+        context "with valid params" do
+          before do
+            @game.title = 'とてもおもしろそうな新タイトル'
+          end
+
+          let(:put_game) {-> {put :update, params: {id: @game.id, game: @game.attributes}}}
+
+          it "don't creates a new Game" do
+            expect {
+              put_game.call
+            }.to change(Game, :count).by(0)
+          end
+
+          it '正常に更新されること' do
+            put_game.call
+            @game.reload
+            expect(@game.title).to eq 'とてもおもしろそうな新タイトル'
+          end
+
+          it "redirects to the game" do
+            put_game.call
+            expect(response).to redirect_to(@game)
+          end
+        end
+
+        context "with invalid params" do
+          before do
+            @game.title = '    '
+          end
+
+          let(:put_game) {-> {put :update, params: {id: @game.id, game: @game.attributes}}}
+
+          it "returns a success response (i.e. to display the 'edit' template)" do
+            put_game.call
+            expect(response).to be_success
+          end
+
+        end
+
+      end
+
+      describe "DELETE #destroy" do
+        let(:delete_game) {-> {delete :destroy, params: {id: @game.id}}}
+
+        it "destroys the requested game" do
+          expect {
+            delete_game.call
+          }.to change(Game, :count).by(-1)
+        end
+
+        it "redirects to the categories list" do
+          delete_game.call
+          expect(response).to redirect_to(games_url)
+        end
+      end
+    end
+
+    describe "他人のゲーム" do
+      before do
+        create(:game)
+        @game = create(:game)
+        create(:game)
+      end
+
+      describe "GET #edit" do
+        context '存在する場合' do
+          before do
+            get :edit, params: {id: @game.id}
+          end
+          it '403になること' do
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+        context '存在しない場合' do
+          it 'raise RecordNotFound' do
+            expect {
+              get :edit, params: {id: 12345}
+            }.to raise_exception(ActiveRecord::RecordNotFound)
+          end
+        end
+      end
+
+      describe "PUT #update" do
+        context "with valid params" do
+          before do
+            @game.title = 'とてもおもしろそうなタイトル'
+            put :update, params: {id: @game.id, game: @game.attributes}
+          end
+          it '403になること' do
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+        context "with invalid params" do
+          before do
+            @game.title = '    '
+            put :update, params: {id: @game.id, game: @game.attributes}
+          end
+          it '403になること' do
+            expect(response).to have_http_status(:forbidden)
+          end
+        end
+
+      end
+
+      describe "DELETE #destroy" do
+        before do
+          delete :destroy, params: {id: @game.id}
+        end
+        it '403になること' do
+          expect(response).to have_http_status(:forbidden)
+        end
+      end
+    end
+
+  end
+
+
+  describe 'ゲストユーザーによるアクセス' do
+    it_behaves_like 'ログイン不要なアクセス'
+    it_behaves_like '非ログインのアクセス'
+  end
+
+  describe '一般ユーザーによるアクセス' do
+    before do
+      @logged_in_user = build(:user)
+      @logged_in_user.skip_confirmation!
+      @logged_in_user.save
+      sign_in @logged_in_user
+    end
+    it_behaves_like 'ログイン不要なアクセス'
+    it_behaves_like '一般ユーザーのアクセス'
+  end
+
+end

--- a/spec/factories/games.rb
+++ b/spec/factories/games.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
 
     user
     category
+
+    factory :invalid_game do
+      title "   "
+    end
   end
 end

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -20,14 +20,20 @@ feature "Game Registeration" do
 
     fill_in 'タイトル', with: 'これはゲームタイトルです。'
     select "シューティング", from: "game_category"
-    fill_in '実況者へ伝えたいこと', with: 'ダウンロードページへのリンクを貼ってね！！！'
     fill_in 'AndroidストアURL', with: 'https://google.com/hogehoge'
     fill_in 'iOSストアURL', with: 'https://google.com/fugafuga'
     fill_in 'ガイドライン', with: "ガイドラインはこちらです！！¥r¥nhttps://www.google.co.jp/search?q=ガイドライン"
+    fill_in '実況者へ伝えたいこと', with: 'ダウンロードページへのリンクを貼ってね！！！'
 
     click_button '作成'
 
     expect(page).to have_text 'これはゲームタイトルです'
+    expect(page).to have_text 'シューティング'
+    #TODO 画像リンクのテスト方法わからない
+    # expect(page).to have_link 'https://google.com/hogehoge'
+    # expect(page).to have_link 'https://google.com/fugafuga'
+    expect(page).to have_text 'ガイドラインはこちらです！！'
+    expect(page).to have_text 'ダウンロードページへのリンクを貼ってね'
   end
 
   scenario "ゲーム一覧" do

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -36,23 +36,4 @@ feature "Game Registeration" do
     expect(page).to have_text 'ダウンロードページへのリンクを貼ってね'
   end
 
-  scenario "ゲーム一覧" do
-    game1 = create(:game)
-    game2 = create(:game)
-    game3 = create(:game)
-
-    # アクセスできること
-    visit games_path
-
-    expect(page).to have_link  game1.title
-    expect(page).to have_link  game2.title
-    expect(page).to have_link  game3.title
-  end
-
-  scenario "ゲーム詳細" do
-    game = create(:game)
-
-    # アクセスできること
-    visit game_path(id: game.id)
-  end
 end

--- a/spec/features/game_registeration_spec.rb
+++ b/spec/features/game_registeration_spec.rb
@@ -20,9 +20,10 @@ feature "Game Registeration" do
 
     fill_in 'タイトル', with: 'これはゲームタイトルです。'
     select "シューティング", from: "game_category"
-    fill_in '条件・要望', with: 'ダウンロードページへのリンクを貼ってね！！！'
+    fill_in '実況者へ伝えたいこと', with: 'ダウンロードページへのリンクを貼ってね！！！'
     fill_in 'AndroidストアURL', with: 'https://google.com/hogehoge'
     fill_in 'iOSストアURL', with: 'https://google.com/fugafuga'
+    fill_in 'ガイドライン', with: "ガイドラインはこちらです！！¥r¥nhttps://www.google.co.jp/search?q=ガイドライン"
 
     click_button '作成'
 

--- a/spec/features/game_update_spec.rb
+++ b/spec/features/game_update_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+feature "Game更新" do
+
+  background do
+    create(:category, name: 'シューティング')
+    cat = create(:category, name: 'アクション')
+    create(:category, name: 'アドベンチャー')
+
+    user = build(:user)
+    user.skip_confirmation!
+    user.save
+    sign_in user
+
+    @game = create(:game, category: cat, user: user)
+  end
+
+  scenario "ゲームを更新" do
+    visit game_path(@game)
+
+    click_link '編集'
+
+    fill_in 'タイトル', with: '新タイトル。'
+    select "アドベンチャー", from: "game_category"
+    fill_in 'AndroidストアURL', with: 'https://google.com/newandroid'
+    fill_in 'iOSストアURL', with: 'https://google.com/newios'
+    fill_in 'ガイドライン', with: "新ガイドライン"
+    fill_in '実況者へ伝えたいこと', with: '伝えたいこと'
+
+    click_button '更新'
+
+    expect(page).to have_text '新タイトル'
+    expect(page).to have_text 'アドベンチャー'
+    #TODO 画像リンクのテスト方法わからない
+    # expect(page).to have_link 'https://google.com/hogehoge'
+    # expect(page).to have_link 'https://google.com/fugafuga'
+    expect(page).to have_text '新ガイドライン'
+    expect(page).to have_text '伝えたいこと'
+  end
+
+end

--- a/spec/features/game_visit_spec.rb
+++ b/spec/features/game_visit_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+feature "Game Visit" do
+
+  scenario "ゲーム一覧" do
+    game1 = create(:game)
+    game2 = create(:game)
+    game3 = create(:game)
+
+    # アクセスできること
+    visit games_path
+
+    expect(page).to have_link game1.title
+    expect(page).to have_link game2.title
+    expect(page).to have_link game3.title
+  end
+
+
+  scenario "ゲーム詳細" do
+    game = create(:game)
+
+    # アクセスできること
+    visit game_path(id: game.id)
+  end
+end

--- a/spec/models/game_spec.rb
+++ b/spec/models/game_spec.rb
@@ -6,6 +6,10 @@ describe Game do
       game = build(:game)
       expect(game).to be_valid
     end
+    it "無効なゲーム" do
+      game = build(:invalid_game)
+      expect(game).not_to be_valid
+    end
   end
 
   describe "バリデーション" do
@@ -20,6 +24,18 @@ describe Game do
 
       context "65文字以上の場合" do
         let(:title) {"a" * 65}
+        it {is_expected.not_to be_valid}
+      end
+    end
+  end
+
+  describe "ガイドライン" do
+    describe ":guideline" do
+      let(:game) {build(:game, guideline: guideline)}
+      subject {game}
+
+      context "513文字以上の場合" do
+        let(:guideline) {"a" * 513}
         it {is_expected.not_to be_valid}
       end
     end


### PR DESCRIPTION
# 注意
PR #57 の上になりたってるので、そちらをマージ後に再度レビューすべき。
（マージ後に一度rebaseした方がよさそう）

# 概要
* gamesにguidelineを追加した
* ゲーム登録・編集フォームでガイドライン入力可能に。
* 条件・要望はガイドラインとの違いがわかりづらいので、`実況者へ伝えたいこと` とした。
    * gamesのカラム名はspecific_conditionsで変更なし。
* 関連する各種テスト追加

# その他

* 本番へデプロイ後、 `specific_conditions` の内容を見ながら `guideline` に手動で移動する予定。60件程度なので目視でも十分できると思う。