### PR TITLE
#41 search ui

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -27,7 +27,6 @@
     font-size: 1.3em;
     content: "\f071";
     color: #F9A825;
-    vertical-align: middle;
 }
 
 .icon-ios:before {

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -10,16 +10,34 @@
     overflow-wrap: break-word;
 }
 
-.android-statue-logo
-{
-    color: #a4c639;
-}
-
-.apple-logo
-{
-    color: #999999
-}
-
 .hidden-element {
     display: none;
+}
+
+.icon {
+    font-family: FontAwesome;
+    font-size: 1.45em;
+    line-height: 0.8em;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+}
+
+.icon-guideline:before {
+    @extend .icon;
+    font-size: 1.3em;
+    content: "\f071";
+    color: #F9A825;
+    vertical-align: middle;
+}
+
+.icon-ios:before {
+    @extend .icon;
+    content: "\f179";
+    color: #999999;
+}
+
+.icon-android:before {
+    @extend .icon;
+    content: "\f17b";
+    color: #a4c639;
 }

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -19,3 +19,7 @@
 {
     color: #999999
 }
+
+.hidden-element {
+    display: none;
+}

--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,5 +1,4 @@
 .ellipsisable-text {
-    width: 100%;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -9,4 +8,14 @@
 {
     word-wrap: break-word;
     overflow-wrap: break-word;
+}
+
+.android-statue-logo
+{
+    color: #a4c639;
+}
+
+.apple-logo
+{
+    color: #999999
 }

--- a/app/assets/stylesheets/game-grid.css
+++ b/app/assets/stylesheets/game-grid.css
@@ -9,6 +9,10 @@
     position: relative;
 }
 
+.boxed-icon-area {
+    display: inline-block;
+}
+
 .boxed a {
     display: block;
     position: absolute;

--- a/app/assets/stylesheets/game-grid.css
+++ b/app/assets/stylesheets/game-grid.css
@@ -1,48 +1,34 @@
-
 .boxed,pre {
     background-color: #fff;
-    border: 1px solid #e4e4e4;
-    border-radius: 6px
+    margin-bottom: 36px;
 }
 
-.push-down-45 {
-    margin-bottom: 45px;
+.boxed-content {
+    margin-left: -10px;
+    margin-right: -10px;
+    position: relative;
+}
+
+.boxed a {
+    display: block;
+    position: absolute;
+    padding-left: -15px;
+    padding-right: -15px;
+    top: 0;
+    left: 0;
+    height: 100%;
+    width: 100%;
 }
 
 .game-icon-image {
     width: 100%;
     height: auto;
     max-height: 700px;
-    border-top-right-radius: 6px;
-    border-top-left-radius: 6px;
-}
-
-.meta {
-    position: relative;
-    margin-bottom: 0
-}
-
-.post-content--front-page {
-    margin-bottom: 30px;
 }
 
 .front-page-title {
-    margin-top: 4px;
-    margin-bottom: 4px;
-    font-size: 22px;
-}
-
-.read-more {
-    border-top: 1px solid #e4e4e4;
-    padding: 18px 5px 20px;
-    text-transform: uppercase;
-    font-size: 14px;
-    font-weight: 700;
-    font-family: Lato,sans-serif;
-    transition: all .1s linear;
-}
-
-.read-more__arrow {
-    display: inline;
-    float: right;
+    margin-top: 2px;
+    margin-bottom: 2px;
+    font-size: 16px;
+    color: #606060;
 }

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -4,11 +4,14 @@
 @import "vars.scss";
 @import "break-point.scss";
 
-@mixin text-prefix-icon
-{
+@mixin text-prefix-icon {
     i {
         margin-right: $text-size / 4;
     }
+}
+
+.search-area {
+    margin-bottom: $text-size / 4;
 }
 
 .condition-area {

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -5,7 +5,7 @@
 @import "break-point.scss";
 
 @mixin text-prefix-icon {
-    i {
+    [class^="icon"]{
         margin-right: $text-size / 4;
     }
 }

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -4,6 +4,34 @@
 @import "vars.scss";
 @import "break-point.scss";
 
+@mixin text-prefix-icon
+{
+    i {
+        margin-right: $text-size / 4;
+    }
+}
+
+.condition-area {
+    @include xs-screen-media {
+       display: none;
+    }
+    @include sm-screen-media {
+       display: none;
+    }
+    @include md-screen-media {
+        display: none;
+    }
+}
+
+.condition-filter-area {
+    @include lg-screen-media {
+       display: none;
+    }
+    @include xl-screen-media {
+        display: none;
+    }
+}
+
 .search-condition-title[aria-expanded=false] .fa-caret-down {
     display:none;
 }
@@ -27,9 +55,7 @@
     margin-bottom: -1px;
     border: 1px solid #ddd;
     border-width: 0 0 1px 0;
-    i {
-        margin-right: $text-size / 4;
-    }
+    @include text-prefix-icon;
     label {
         padding-left: $text-size / 2;
         font-weight: 100;
@@ -38,4 +64,18 @@
     input {
         margin-left: $text-size;
     }
+}
+
+input[type=checkbox]:checked ~ div.condition-area {
+    display: block;
+}
+
+.filter-btn {
+    margin-bottom: $text-size;
+    @include text-prefix-icon;
+}
+
+input[type=checkbox]:checked ~ .filter-btn {
+    display: block;
+    margin-bottom: 0px;
 }

--- a/app/assets/stylesheets/search.scss
+++ b/app/assets/stylesheets/search.scss
@@ -1,0 +1,41 @@
+// Place all the styles related to the Games controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/
+@import "vars.scss";
+@import "break-point.scss";
+
+.search-condition-title[aria-expanded=false] .fa-caret-down {
+    display:none;
+}
+
+.search-condition-title[aria-expanded=true] .fa-caret-right {
+    display:none;
+}
+
+.box-joint {
+    margin-bottom: -1px;
+}
+
+.condition-box {
+    font-size: $text-size;
+}
+
+.condition-item {
+    position: relative;
+    display: block;
+    padding: 2px $text-size;
+    margin-bottom: -1px;
+    border: 1px solid #ddd;
+    border-width: 0 0 1px 0;
+    i {
+        margin-right: $text-size / 4;
+    }
+    label {
+        padding-left: $text-size / 2;
+        font-weight: 100;
+        font-size: 0.8em;
+    }
+    input {
+        margin-left: $text-size;
+    }
+}

--- a/app/assets/stylesheets/vars.scss
+++ b/app/assets/stylesheets/vars.scss
@@ -1,5 +1,7 @@
 $xs-screen: "(max-width: 575px)";
 $sm-screen: "(min-width:576px) and (max-width: 767px)";
 $md-screen: "(min-width: 768px) and (max-width: 991px)";
-$lg-screen: "(min-width: 992px)" and "(max-width: 1199px)";
+$lg-screen: "(min-width: 992px) and (max-width: 1199px)";
 $xl-screen: "(min-width: 1200px)";
+
+$text-size: 18px;

--- a/app/controllers/api/games_controller.rb
+++ b/app/controllers/api/games_controller.rb
@@ -5,7 +5,7 @@ module Api
     def index
 
       pp params
-      games = Game.select(:id, :title, :icon, :android_url, :ios_url)
+      games = Game.select(:id, :title, :icon, :guideline, :android_url, :ios_url)
 
       unless params[:category].blank?
         games = games.where(category_id: params[:category])

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -79,8 +79,7 @@
                             <span v-text="game.title"></span>
                         </div>
                         <div>
-                            <!-- TODO: ガイドラインの有無に変更する -->
-                            <span class="icon-guideline" v-if="game.permission" aria-hidden="true"></span>
+                            <span class="icon-guideline" v-if="game.guideline !== null && game.guideline.length > 0 " aria-hidden="true"></span>
                             <span class="icon-android" v-if="game.android_url.length > 0" aria-hidden="true"></span>
                             <span class="icon-ios" v-if="game.ios_url.length > 0" aria-hidden="true"></span>
                         </div>
@@ -102,7 +101,6 @@
                     categories: {}
                 },
                 formValues: {
-                    permission: "",
                     category: "",
                     platform: ""
                 }

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -16,34 +16,6 @@
 
             <div class="condition-area">
                 <div class="panel panel-default condition-box box-joint">
-                    <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#guideline-condition" aria-expanded="true" aria-controls="guideline-chevron">
-                        <i class="fa fa-caret-right" aria-hidden="true"></i>
-                        <i class="fa fa-caret-down" aria-hidden="true"></i>
-                        ガイドライン
-                    </div>
-                    <ul class="list-group collapse in" id="guideline-condition">
-                        <li class="condition-item">
-                            <input type="radio" id="radPermissionAll" value="" v-model="formValues.permission"
-                                                                               v-on:change="getGames">
-                            <label for="radPermissionAll">すべて</label>
-                        </li>
-                        <li class="condition-item">
-                            <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
-                                                                                   v-on:change="getGames">
-                            <label for="radPermissionNG">
-                                なし
-                            </label>
-                        </li>
-                        <li class="condition-item">
-                            <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
-                                                                                  v-on:change="getGames">
-                            <label for="radPermissionOK">
-                                <span class="icon-guideline" aria-hidden="true"></span>あり
-                            </label>
-                        </li>
-                    </ul>
-                </div>
-                <div class="panel panel-default condition-box box-joint">
                     <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#platform-condition" aria-expanded="true" aria-controls="platform-chevron">
                         <i class="fa fa-caret-right" aria-hidden="true"></i>
                         <i class="fa fa-caret-down" aria-hidden="true"></i>

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -1,81 +1,89 @@
 <template>
     <div class="row">
-        <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
-            <div class="panel panel-default condition-box box-joint">
-                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#guideline-condition" aria-expanded="true" aria-controls="guideline-chevron">
-                    <i class="fa fa-caret-right" aria-hidden="true"></i>
-                    <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    ガイドライン
-                </div>
-                <ul class="list-group collapse in" id="guideline-condition">
-                    <li class="condition-item">
-                        <input type="radio" id="radPermissionAll" value="" v-model="formValues.permission"
-                                                                           v-on:change="getGames">
-                        <label for="radPermissionAll">すべて</label>
-                    </li>
-                    <li class="condition-item">
-                        <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
-                                                                              v-on:change="getGames">
-                        <label for="radPermissionOK">
-                            <i class="fa fa-warning fa-lg text-warning" aria-hidden="true"></i>あり
-                        </label>
-                    </li>
-                    <li class="condition-item">
-                        <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
+            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
+            <input type="checkbox" id="filtering" class="hidden-element condition-filter-area">
+            <label for="filtering" class="btn btn-warning btn-block condition-filter-area filter-btn">
+                <i class="fa fa-filter"></i>条件で絞りこみ
+            </label>
+
+            <div class="condition-area">
+                <div class="panel panel-default condition-box box-joint">
+                    <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#guideline-condition" aria-expanded="true" aria-controls="guideline-chevron">
+                        <i class="fa fa-caret-right" aria-hidden="true"></i>
+                        <i class="fa fa-caret-down" aria-hidden="true"></i>
+                        ガイドライン
+                    </div>
+                    <ul class="list-group collapse in" id="guideline-condition">
+                        <li class="condition-item">
+                            <input type="radio" id="radPermissionAll" value="" v-model="formValues.permission"
                                                                                v-on:change="getGames">
-                        <label for="radPermissionNG">
-                            <i class="fa fa-check-circle-o fa-lg text-success" aria-hidden="true"></i>なし
-                        </label>
-                    </li>
-                </ul>
-            </div>
-            <div class="panel panel-default condition-box box-joint">
-                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#platform-condition" aria-expanded="true" aria-controls="platform-chevron">
-                    <i class="fa fa-caret-right" aria-hidden="true"></i>
-                    <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    プラットフォーム
+                            <label for="radPermissionAll">すべて</label>
+                        </li>
+                        <li class="condition-item">
+                            <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
+                                                                                  v-on:change="getGames">
+                            <label for="radPermissionOK">
+                                <i class="fa fa-warning fa-lg text-warning" aria-hidden="true"></i>あり
+                            </label>
+                        </li>
+                        <li class="condition-item">
+                            <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
+                                                                                   v-on:change="getGames">
+                            <label for="radPermissionNG">
+                                <i class="fa fa-check-circle-o fa-lg text-success" aria-hidden="true"></i>なし
+                            </label>
+                        </li>
+                    </ul>
                 </div>
-                <ul class="list-group collapse in" id="platform-condition">
-                    <li class="condition-item">
-                        <input type="radio" id="radPlatformAll" value="" v-model="formValues.platform" v-on:change="getGames">
-                        <label for="radPlatformAll">すべて</label>
-                    </li>
-                    <li class="condition-item">
-                        <input type="radio" id="radPlatformAndroid" value="android" v-model="formValues.platform"
-                                                                                    v-on:change="getGames">
-                        <label for="radPlatformAndroid">
-                            <i class="fa fa-android fa-lg android-statue-logo" aria-hidden="true"></i>Android
-                        </label>
-                    </li>
-                    <li class="condition-item">
-                        <input type="radio" id="radPlatformIOS" value="ios" v-model="formValues.platform"
-                                                                            v-on:change="getGames">
-                        <label for="radPlatformIOS">
-                            <i class="fa fa-apple fa-lg apple-logo" aria-hidden="true"></i>iOS
-                        </label>
-                    </li>
-                </ul>
+                <div class="panel panel-default condition-box box-joint">
+                    <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#platform-condition" aria-expanded="true" aria-controls="platform-chevron">
+                        <i class="fa fa-caret-right" aria-hidden="true"></i>
+                        <i class="fa fa-caret-down" aria-hidden="true"></i>
+                        プラットフォーム
+                    </div>
+                    <ul class="list-group collapse in" id="platform-condition">
+                        <li class="condition-item">
+                            <input type="radio" id="radPlatformAll" value="" v-model="formValues.platform" v-on:change="getGames">
+                            <label for="radPlatformAll">すべて</label>
+                        </li>
+                        <li class="condition-item">
+                            <input type="radio" id="radPlatformAndroid" value="android" v-model="formValues.platform"
+                                                                                        v-on:change="getGames">
+                            <label for="radPlatformAndroid">
+                                <i class="fa fa-android fa-lg android-statue-logo" aria-hidden="true"></i>Android
+                            </label>
+                        </li>
+                        <li class="condition-item">
+                            <input type="radio" id="radPlatformIOS" value="ios" v-model="formValues.platform"
+                                                                                v-on:change="getGames">
+                            <label for="radPlatformIOS">
+                                <i class="fa fa-apple fa-lg apple-logo" aria-hidden="true"></i>iOS
+                            </label>
+                        </li>
+                    </ul>
+                </div>
+
+                <div class="panel panel-default condition-box">
+                    <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#genre-condition" aria-expanded="true" aria-controls="genre-chevron">
+                        <i class="fa fa-caret-right" aria-hidden="true"></i>
+                        <i class="fa fa-caret-down" aria-hidden="true"></i>
+                        ジャンル
+                    </div>
+                    <ul class="list-group collapse in" id="genre-condition">
+                        <li class="condition-item">
+                            <input type="radio" id="radCategoryAll" value="" v-model="formValues.category" v-on:change="getGames">
+                            <label for="radCategoryAll">すべて</label>
+                        </li>
+                        <li class="condition-item" v-for="category in masterData.categories">
+                            <input type="radio" :id="'radCategory' + category.id" :value="category.id" v-model="formValues.category"
+                                                                                                       v-on:change="getGames">
+                            <label :for="'radCategory' + category.id" v-text="category.name"></label>
+                        </li>
+                    </ul>
+                </div>
+            </div>
             </div>
 
-            <div class="panel panel-default condition-box">
-                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#genre-condition" aria-expanded="true" aria-controls="genre-chevron">
-                    <i class="fa fa-caret-right" aria-hidden="true"></i>
-                    <i class="fa fa-caret-down" aria-hidden="true"></i>
-                    ジャンル
-                </div>
-                <ul class="list-group collapse in" id="genre-condition">
-                    <li class="condition-item">
-                        <input type="radio" id="radCategoryAll" value="" v-model="formValues.category" v-on:change="getGames">
-                        <label for="radCategoryAll">すべて</label>
-                    </li>
-                    <li class="condition-item" v-for="category in masterData.categories">
-                        <input type="radio" :id="'radCategory' + category.id" :value="category.id" v-model="formValues.category"
-                                                                                                   v-on:change="getGames">
-                        <label :for="'radCategory' + category.id" v-text="category.name"></label>
-                    </li>
-                </ul>
-            </div>
-        </div>
         <div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
             <div v-if="games.length === 0">
                 <h3>見つかりませんでした。</h3>

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -1,6 +1,14 @@
 <template>
     <div class="row">
-            <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
+        <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
+            <!-- TODO: サーバサイド実装後に対応 -->
+            <div class="input-group search-area">
+                <input class="form-control" type="text"  placeholder="ゲームタイトルで探す" />
+                <span class="input-group-btn">
+                    <button class="btn btn-primary" type="button"><i class="fa fa-search" aria-hidden="true"></i></button>
+                </span>
+            </div>
+
             <input type="checkbox" id="filtering" class="hidden-element condition-filter-area">
             <label for="filtering" class="btn btn-warning btn-block condition-filter-area filter-btn">
                 <i class="fa fa-filter"></i>条件で絞りこみ
@@ -82,7 +90,7 @@
                     </ul>
                 </div>
             </div>
-            </div>
+        </div>
 
         <div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
             <div v-if="games.length === 0">

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -78,7 +78,7 @@
                         <div class="front-page-title ellipsisable-text">
                             <span v-text="game.title"></span>
                         </div>
-                        <div>
+                        <div class="boxed-icon-area">
                             <span class="icon-guideline" v-if="game.guideline !== null && game.guideline.length > 0 " aria-hidden="true"></span>
                             <span class="icon-android" v-if="game.android_url.length > 0" aria-hidden="true"></span>
                             <span class="icon-ios" v-if="game.ios_url.length > 0" aria-hidden="true"></span>

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -1,46 +1,79 @@
 <template>
     <div class="row">
         <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
-            <h2>実況可否</h2>
-            <div>
-                <input type="radio" id="radPermissionAll" value="" v-model="formValues.permission"
-                       v-on:change="getGames">
-                <label for="radPermissionAll">すべて</label>
+            <div class="panel panel-default condition-box box-joint">
+                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#guideline-condition" aria-expanded="true" aria-controls="guideline-chevron">
+                    <i class="fa fa-caret-right" aria-hidden="true"></i>
+                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                    ガイドライン
+                </div>
+                <ul class="list-group collapse in" id="guideline-condition">
+                    <li class="condition-item">
+                        <input type="radio" id="radPermissionAll" value="" v-model="formValues.permission"
+                                                                           v-on:change="getGames">
+                        <label for="radPermissionAll">すべて</label>
+                    </li>
+                    <li class="condition-item">
+                        <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
+                                                                              v-on:change="getGames">
+                        <label for="radPermissionOK">
+                            <i class="fa fa-warning fa-lg text-warning" aria-hidden="true"></i>あり
+                        </label>
+                    </li>
+                    <li class="condition-item">
+                        <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
+                                                                               v-on:change="getGames">
+                        <label for="radPermissionNG">
+                            <i class="fa fa-check-circle-o fa-lg text-success" aria-hidden="true"></i>なし
+                        </label>
+                    </li>
+                </ul>
             </div>
-            <div>
-                <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
-                       v-on:change="getGames">
-                <label for="radPermissionOK">実況OK</label>
+            <div class="panel panel-default condition-box box-joint">
+                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#platform-condition" aria-expanded="true" aria-controls="platform-chevron">
+                    <i class="fa fa-caret-right" aria-hidden="true"></i>
+                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                    プラットフォーム
+                </div>
+                <ul class="list-group collapse in" id="platform-condition">
+                    <li class="condition-item">
+                        <input type="radio" id="radPlatformAll" value="" v-model="formValues.platform" v-on:change="getGames">
+                        <label for="radPlatformAll">すべて</label>
+                    </li>
+                    <li class="condition-item">
+                        <input type="radio" id="radPlatformAndroid" value="android" v-model="formValues.platform"
+                                                                                    v-on:change="getGames">
+                        <label for="radPlatformAndroid">
+                            <i class="fa fa-android fa-lg android-statue-logo" aria-hidden="true"></i>Android
+                        </label>
+                    </li>
+                    <li class="condition-item">
+                        <input type="radio" id="radPlatformIOS" value="ios" v-model="formValues.platform"
+                                                                            v-on:change="getGames">
+                        <label for="radPlatformIOS">
+                            <i class="fa fa-apple fa-lg apple-logo" aria-hidden="true"></i>iOS
+                        </label>
+                    </li>
+                </ul>
             </div>
-            <div>
-                <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
-                       v-on:change="getGames">
-                <label for="radPermissionNG">実況NG</label>
-            </div>
-            <h2>プラットフォーム</h2>
-            <div>
-                <input type="radio" id="radPlatformAll" value="" v-model="formValues.platform" v-on:change="getGames">
-                <label for="radPlatformAll">すべて</label>
-            </div>
-            <div>
-                <input type="radio" id="radPlatformAndroid" value="android" v-model="formValues.platform"
-                       v-on:change="getGames">
-                <label for="radPlatformAndroid">Android</label>
-            </div>
-            <div>
-                <input type="radio" id="radPlatformIOS" value="ios" v-model="formValues.platform"
-                       v-on:change="getGames">
-                <label for="radPlatformIOS">iOS</label>
-            </div>
-            <h2>ジャンル</h2>
-            <div>
-                <input type="radio" id="radCategoryAll" value="" v-model="formValues.category" v-on:change="getGames">
-                <label for="radCategoryAll">すべて</label>
-            </div>
-            <div v-for="category in masterData.categories">
-                <input type="radio" :id="'radCategory' + category.id" :value="category.id" v-model="formValues.category"
-                       v-on:change="getGames">
-                <label :for="'radCategory' + category.id" v-text="category.name"></label>
+
+            <div class="panel panel-default condition-box">
+                <div class="panel-heading search-condition-title" data-toggle="collapse" data-target="#genre-condition" aria-expanded="true" aria-controls="genre-chevron">
+                    <i class="fa fa-caret-right" aria-hidden="true"></i>
+                    <i class="fa fa-caret-down" aria-hidden="true"></i>
+                    ジャンル
+                </div>
+                <ul class="list-group collapse in" id="genre-condition">
+                    <li class="condition-item">
+                        <input type="radio" id="radCategoryAll" value="" v-model="formValues.category" v-on:change="getGames">
+                        <label for="radCategoryAll">すべて</label>
+                    </li>
+                    <li class="condition-item" v-for="category in masterData.categories">
+                        <input type="radio" :id="'radCategory' + category.id" :value="category.id" v-model="formValues.category"
+                                                                                                   v-on:change="getGames">
+                        <label :for="'radCategory' + category.id" v-text="category.name"></label>
+                    </li>
+                </ul>
             </div>
         </div>
         <div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
@@ -108,11 +141,3 @@
         },
     }
 </script>
-<style scoped>
-    .front-page-title {
-        font-size: 1em;
-    }
-    .post-content--front-page{
-        margin-bottom :0;
-    }
-</style>

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -82,19 +82,18 @@
                 <p>このサービスに登録されていないゲームについては、開発者に直接お問い合わせください。</p>
             </div>
             <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3" v-for="game in games">
-
-                <div class="boxed push-down-45">
-                    <div class="meta">
+                <!-- Start of the content -->
+                <div class="boxed">
+                    <div class="boxed-content">
+                        <a :href="'/games/' + game.id"></a>
                         <img class="game-icon-image" :src="game.icon.thumb.url">
-                    </div>
-                    <div class="row">
-                        <div class="col-xs-10 col-xs-offset-1 ">
-                            <!-- Start of the content -->
-                            <div class="post-content--front-page">
-                                <h1 class="front-page-title">
-                                    <a :href="'/games/' + game.id" v-text="game.title"></a>
-                                </h1>
-                            </div>
+                        <div class="front-page-title ellipsisable-text">
+                            <span v-text="game.title"></span>
+                        </div>
+                        <div>
+                            <i class="fa fa-warning fa-lg text-warning" v-if="game.permission" aria-hidden="true"></i>
+                            <i class="fa fa-android fa-lg android-statue-logo" v-if="game.android_url.length > 0" aria-hidden="true"></i>
+                            <i class="fa fa-apple fa-lg apple-logo" v-if="game.ios_url.length > 0" aria-hidden="true"></i>
                         </div>
                     </div>
                 </div>

--- a/app/javascript/packs/game_search.vue
+++ b/app/javascript/packs/game_search.vue
@@ -28,17 +28,17 @@
                             <label for="radPermissionAll">すべて</label>
                         </li>
                         <li class="condition-item">
-                            <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
-                                                                                  v-on:change="getGames">
-                            <label for="radPermissionOK">
-                                <i class="fa fa-warning fa-lg text-warning" aria-hidden="true"></i>あり
-                            </label>
-                        </li>
-                        <li class="condition-item">
                             <input type="radio" id="radPermissionNG" value="false" v-model="formValues.permission"
                                                                                    v-on:change="getGames">
                             <label for="radPermissionNG">
-                                <i class="fa fa-check-circle-o fa-lg text-success" aria-hidden="true"></i>なし
+                                なし
+                            </label>
+                        </li>
+                        <li class="condition-item">
+                            <input type="radio" id="radPermissionOK" value="true" v-model="formValues.permission"
+                                                                                  v-on:change="getGames">
+                            <label for="radPermissionOK">
+                                <span class="icon-guideline" aria-hidden="true"></span>あり
                             </label>
                         </li>
                     </ul>
@@ -58,14 +58,14 @@
                             <input type="radio" id="radPlatformAndroid" value="android" v-model="formValues.platform"
                                                                                         v-on:change="getGames">
                             <label for="radPlatformAndroid">
-                                <i class="fa fa-android fa-lg android-statue-logo" aria-hidden="true"></i>Android
+                                <span class="icon-android" aria-hidden="true"></span>Android
                             </label>
                         </li>
                         <li class="condition-item">
                             <input type="radio" id="radPlatformIOS" value="ios" v-model="formValues.platform"
                                                                                 v-on:change="getGames">
                             <label for="radPlatformIOS">
-                                <i class="fa fa-apple fa-lg apple-logo" aria-hidden="true"></i>iOS
+                                <span class="icon-ios" aria-hidden="true"></span>iOS
                             </label>
                         </li>
                     </ul>
@@ -107,9 +107,10 @@
                             <span v-text="game.title"></span>
                         </div>
                         <div>
-                            <i class="fa fa-warning fa-lg text-warning" v-if="game.permission" aria-hidden="true"></i>
-                            <i class="fa fa-android fa-lg android-statue-logo" v-if="game.android_url.length > 0" aria-hidden="true"></i>
-                            <i class="fa fa-apple fa-lg apple-logo" v-if="game.ios_url.length > 0" aria-hidden="true"></i>
+                            <!-- TODO: ガイドラインの有無に変更する -->
+                            <span class="icon-guideline" v-if="game.permission" aria-hidden="true"></span>
+                            <span class="icon-android" v-if="game.android_url.length > 0" aria-hidden="true"></span>
+                            <span class="icon-ios" v-if="game.ios_url.length > 0" aria-hidden="true"></span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
### 一覧画面関連
* ゲーム一覧画面のゲームパネルのUIを変更しました。
* ゲーム一覧画面の検索フォームのUIを調整しました(雑にレスポンシブ対応済み)。

### ガイドライン関連
* ガイドラインの情報も返すようにAPIを変更しました。
* ガイドラインがある場合、「！」マークのアイコンを表示するように暫定対応しました。

### その他
* 将来に備えてFontAwesomeのアイコンをcssで別名定義しました。
* 将来に備えて動いても何も機能しない検索ボックスを配置しておきました

## 残タスク
* /games2 から /games への乗り換え