### PR TITLE
#38-パスワード再設定画面UIの作成&ユーザー登録用htmlコードの一部修正

### DIFF
--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,25 +1,37 @@
-<h2>Change your password</h2>
+<div class="row">
+  <div class="col-xs-12 col-sm-7 col-md-6 col-sm-2 col-md-offset-3">
+    <div class="well bs-component">
+      <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+      <%= f.hidden_field :reset_password_token %>
+      
+      <fieldset>
+        <legend>パスワードの変更</legend>
 
-<%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
-  <%= devise_error_messages! %>
-  <%= f.hidden_field :reset_password_token %>
+        <% if resource.errors.any? %>
+          <div class="form-group">
+            <div class="col-lg-9 col-lg-offset-3 text-danger">
+              <%= "#{resource.errors.count}件のエラーがあります。" %>
+              <% resource.errors.full_messages.each do |msg| %>
+                  <span class="help-block"><%= "・#{msg}" %></span>
+              <% end %>
+            </div>
+          </div>
+        <% end %>
 
-  <div class="field">
-    <%= f.label :password, "New password" %><br />
-    <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+        <div class="col-md-12">
+          <div class="form-group">
+            <%= f.label :password, "新しいパスワード" %><br />
+            <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: '6文字以上入力して下さい' %>
+          </div>
+
+          <div class="form-group">
+            <%= f.label :password_confirmation, "パスワード(確認)" %><br />
+            <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: '再度パスワードを入力してください' %>
+          </div>
+        </div>
+        <%= f.submit "変更", class:'btn btn-success btn-block' %>
+      </fieldset>
+    </div>
     <% end %>
-    <%= f.password_field :password, autofocus: true, autocomplete: "off" %>
   </div>
-
-  <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
-    <%= f.password_field :password_confirmation, autocomplete: "off" %>
-  </div>
-
-  <div class="actions">
-    <%= f.submit "Change my password" %>
-  </div>
-<% end %>
-
-<%= render "devise/shared/links" %>
+</div>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,9 +2,8 @@
   <div class="col-xs-12 col-sm-7 col-md-6 col-md-offset-1">
     <div class="well bs-component">
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'form-horizontal'}) do |f| %>
+      <fieldset>
           <legend>新規ユーザー登録</legend>
-          <fieldset>
-
             <% if resource.errors.any? %>
                 <div class="form-group">
                   <div class="col-lg-9 col-lg-offset-3 text-danger">
@@ -46,5 +45,3 @@
     <%= render "devise/shared/links" %>
   </div>
 </div>
-
-


### PR DESCRIPTION
Fixes #38 

## 変更箇所

  *UIを他の登録UIに合わせて変更
  *ヘルプとして表示するコンテンツが今のところ存在しないので削除
