### PR TITLE
fix #93 sort by created_at

### DIFF
--- a/app/javascript/packs/components/game_search.vue
+++ b/app/javascript/packs/components/game_search.vue
@@ -66,11 +66,11 @@
         </div>
 
         <div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
-            <div v-if="games.length === 0">
+            <div v-if="orderdGames.length === 0">
                 <h3>見つかりませんでした。</h3>
                 <p>このサービスに登録されていないゲームについては、開発者に直接お問い合わせください。</p>
             </div>
-            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3" v-for="game in games">
+            <div class="col-xs-12 col-sm-4 col-md-4 col-lg-3" v-for="game in orderdGames">
                 <!-- Start of the content -->
                 <div class="boxed">
                     <div class="boxed-content">
@@ -98,7 +98,7 @@
         props: ['msg'],
         data: function () {
             return {
-                games: {},
+                games: [],
                 masterData: {
                     categories: {},
                     platforms: {}
@@ -108,6 +108,15 @@
                     category: "",
                     platform: ""
                 }
+            }
+        },
+        computed: {
+            orderdGames: function () {
+                return this.games.sort(function (a, b) {
+                    if (a.created_at > b.created_at) return -1
+                    if (a.created_at < b.created_at) return 1
+                    return 0
+                })
             }
         },
         created: function () {

--- a/app/views/api/games/index.json.jbuilder
+++ b/app/views/api/games/index.json.jbuilder
@@ -1,9 +1,12 @@
+
 json.games @games do |game|
   json.id game.id
   json.title game.title
   json.specific_conditions game.specific_conditions
   json.category_id game.category_id
   json.guideline game.guideline
+  json.created_at game.created_at
+  json.updated_at game.updated_at
   json.icon do
     json.thumb do
       json.url game.icon.thumb.url


### PR DESCRIPTION
Fixes #93

## 変更箇所

* ゲーム一覧を登録日降順にソートしました。
* `games: {}` だと`.sort` なかったので `games: []` に変えました。
    * よくわかってないけど動いてるっぽいのでいいかな？