### PR TITLE
#99 add recent_tags parameter in game registration

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -109,7 +109,7 @@ class GamesController < ApplicationController
   end
 
   def set_recent_tags
-    @recent_tags = Tag.order(created_at: :desc).take(10)
+    @recent_tags = Tag.order(created_at: :desc).limit(10)
   end
 
   # Never trust parameters from the scary internet, only allow the white list through.

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -2,7 +2,7 @@ class GamesController < ApplicationController
   before_action :set_game, only: [:show, :edit, :update, :destroy]
   before_action :set_categories, only: [:new, :edit, :create, :update]
   before_action :set_platforms, only: [:new, :edit, :create, :update]
-  before_action :set_recent_tags, only: [:new, :edit]
+  before_action :set_recent_tags, only: [:new, :edit, :create, :update]
   before_action :authenticate_user!, only: [:new, :edit, :create, :update, :destroy]
   before_action :correct_user, only: [:edit, :update, :destroy]
 
@@ -46,7 +46,6 @@ class GamesController < ApplicationController
       redirect_to @game, notice: '登録しました。'
     else
       flash.now[:alert] = "エラーがあるため登録できませんでした。"
-      set_recent_tags
       render :new
     end
 
@@ -81,7 +80,6 @@ class GamesController < ApplicationController
       redirect_to @game, notice: '更新しました。'
     else
       flash.now[:alert] = "エラーがあるため更新できませんでした。"
-      set_recent_tags
       render :edit
     end
   end

--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -46,6 +46,7 @@ class GamesController < ApplicationController
       redirect_to @game, notice: '登録しました。'
     else
       flash.now[:alert] = "エラーがあるため登録できませんでした。"
+      set_recent_tags
       render :new
     end
 
@@ -80,6 +81,7 @@ class GamesController < ApplicationController
       redirect_to @game, notice: '更新しました。'
     else
       flash.now[:alert] = "エラーがあるため更新できませんでした。"
+      set_recent_tags
       render :edit
     end
   end

--- a/spec/controllers/games_controller_spec.rb
+++ b/spec/controllers/games_controller_spec.rb
@@ -126,6 +126,7 @@ describe GamesController do
       context "with invalid params" do
         it "returns a success response (i.e. to display the 'new' template)" do
           post :create, params: {game: build(:invalid_game).attributes}
+          expect(assigns(:recent_tags)).not_to be_nil
           expect(response).to be_success
         end
       end
@@ -197,6 +198,7 @@ describe GamesController do
 
           it "returns a success response (i.e. to display the 'edit' template)" do
             put_game.call
+            expect(assigns(:recent_tags)).not_to be_nil
             expect(response).to be_success
           end
 


### PR DESCRIPTION
Fixes #99

## 変更箇所

  * renderではbefore_actionで値が設定されていないようなので、バリデーション失敗時に手動で @recent_tagsが設定されるようにしました。
  * テストで recent_tags が nil でないことを検証するようにしました。
