### PR TITLE
#87 add tooltip style

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -1,32 +1,34 @@
+@import "vars.scss";
+
 $header-text-margin: 8px;
 $heading-font-size: 24px;
 
 .ellipsisable-text {
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .foldable-text
 {
-    word-wrap: break-word;
-    overflow-wrap: break-word;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .hidden-element {
-    display: none!important;
+  display: none!important;
 }
 
 .google-play-badge {
-    width: 180px;
-    display:inline-block;
+  width: 180px;
+  display:inline-block;
 }
 
 .apple-store-badge {
-    width: 130px;
-    // google playのBadgeに画像サイズ合わせるために設定
-    margin: 12px;
-    display:inline-block;
+  width: 130px;
+  // google playのBadgeに画像サイズ合わせるために設定
+  margin: 12px;
+  display:inline-block;
 }
 
 .header-text {
@@ -34,5 +36,34 @@ $heading-font-size: 24px;
     font-weight: bold;
     margin-bottom: $header-text-margin;
     font-size: $heading-font-size;
+  }
+}
+
+[tooltip] {
+  position: relative;
+  &:after {
+    font-size: 12px;
+    opacity: 0;
+    visibility: hidden;
+    position: absolute;
+    content: attr(tooltip);
+    padding: 2px 7px;
+    top: $text-size * 1.2;
+    left: 50%;
+    transform: translateX(-50%);
+    background: black;
+    border-radius: 6px;
+    color: white;
+    white-space: nowrap;
+    z-index: 2;
+  }
+  &:hover {
+    &:after {
+      display: block;
+      opacity: 0.7;
+      visibility: visible;
+      left: 50%;
+      transform: translateX(-50%);
+    }
   }
 }

--- a/app/javascript/packs/components/game_search.vue
+++ b/app/javascript/packs/components/game_search.vue
@@ -83,7 +83,7 @@
                             <span class="icon-guideline" v-if="game.guideline !== null && game.guideline.length > 0 "
                                   aria-hidden="true"></span>
                             <span :class="'platform-icon icon-' + p.code" v-for="p in masterData.platforms"
-                                  v-if="game['has_' + p.code]" aria-hidden="true"></span>
+                                  v-if="game['has_' + p.code]" aria-hidden="true" v-bind:tooltip="p.name"></span>
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
Fixes #87

## 変更箇所

  * ゲーム一覧画面のゲームごとのパネルの中にあるプラットフォームアイコンにのみツールチップが表示されるようにしました。
  * 絞り込みのところにアイコンとプラットフォームの対応が書かれているので不要かも？と思いましたが、ホバーしない限り見えることはなく邪魔にはならないと思うので追加しちゃいました。
