### PR TITLE
#110 reposition error message

### DIFF
--- a/app/assets/stylesheets/common.scss
+++ b/app/assets/stylesheets/common.scss
@@ -125,3 +125,10 @@ body {
   font-family: Verdana;
   font-weight: bold;
 }
+
+.input-form-error {
+  font-size: 0.8em;
+  display: block;
+  text-align: right;
+  margin-bottom: $text-size / 2;
+}

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,5 +1,6 @@
 class Users::RegistrationsController < Devise::RegistrationsController
-  prepend_before_action :authenticate_scope!, only: [:edit, :update, :destroy, :games]
+  prepend_before_action :authenticate_scope!, only: [:edit, :games, :update, :destroy]
+  layout 'user_profile_layout', only: [:edit, :games, :update]
 
   def cancel
     super
@@ -14,11 +15,9 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def edit
-    render :layout => 'user_profile_layout'
   end
 
   def games
-    render :layout => 'user_profile_layout'
   end
 
   def update
@@ -38,6 +37,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     else
       resource.update_without_password(params)
     end
+  end
+
+  def after_update_path_for(resource)
+    edit_user_registration_path
   end
 
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -1,0 +1,45 @@
+module FormHelper
+  class FormWithErrorMessageBuilder < ActionView::Helpers::FormBuilder
+    def text_field(attribute, options={})
+      input_field_with_error(attribute, options) do
+        super 
+      end
+    end
+
+    def email_field(attribute, options={})
+      input_field_with_error(attribute, options) do
+        super
+      end
+    end
+
+    def password_field(attribute, options={})
+      input_field_with_error(attribute, options) do
+        super
+      end
+    end
+
+    def select(class_name, attribute, select_items, default, options={})
+      input_field_with_error(class_name, options) do
+        super(attribute, select_items, default, options)
+      end
+    end
+
+    def input_field_with_error(attribute, options={}, &block)
+      error_messages = @object.errors.full_messages_for(attribute)
+      if error_messages.any?
+        options[:class] << " is-invalid"
+        error_contents = create_error_div(attribute, error_messages)
+      end
+
+      block.call + error_contents || ""
+    end
+
+    def create_error_div(attribute, messages)
+      @template.content_tag(:div, class: "input-form-error text-danger") do
+        messages.each do |message|
+          @template.concat(@template.content_tag(:div, message))
+        end
+      end
+    end
+  end
+end

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,22 +1,12 @@
 <% provide(:html_title, "確認メールの再送") %>
 <div class="row">
   <div class="col-12 col-md-7 offset-md-1 form-area">
-    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post, class: 'form-horizontal'}) do |f| %>
+    <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: {method: :post, class: 'form-horizontal'}, :builder => FormHelper::FormWithErrorMessageBuilder) do |f| %>
       <div class="col-md-12">
         <span class="header-text">
           メールアドレス確認メールの再送
         </span>
         <fieldset>
-          <% if resource.errors.any? %>
-            <div class="form-group">
-              <div class="col-lg-9 col-lg-offset-3 text-danger">
-                <%= "#{resource.errors.count}件のエラーがあります。" %>
-                <% resource.errors.full_messages.each do |msg| %>
-                  <span class="help-block"><%= "・#{msg}" %></span>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
           <div class="form-group">
             <label for="user_email" class="control-label">メールアドレス</label>
             <%= f.email_field :email, id: :user_email, class: 'form-control' %>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,7 +1,7 @@
 <% provide(:html_title, "パスワードの変更") %>
 <div class="row">
   <div class="col-12 col-sm-7 col-md-6 col-sm-2 offset-md-3 form-area">
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }, :builder => FormHelper::FormWithErrorMessageBuilder) do |f| %>
       <%= f.hidden_field :reset_password_token %>
 
       <fieldset>
@@ -9,25 +9,14 @@
           パスワードの変更
         </span>
 
-        <% if resource.errors.any? %>
-          <div class="form-group">
-            <div class="col-lg-9 col-lg-offset-3 text-danger">
-              <%= "#{resource.errors.count}件のエラーがあります。" %>
-              <% resource.errors.full_messages.each do |msg| %>
-                <span class="help-block"><%= "・#{msg}" %></span>
-              <% end %>
-            </div>
-          </div>
-        <% end %>
-
         <div class="col-md-12">
           <div class="form-group">
-            <%= f.label :password, "新しいパスワード" %><br />
+            <%= f.label :password, "新しいパスワード" %>
             <%= f.password_field :password, autocomplete: "off", class: 'form-control', placeholder: '6文字以上入力して下さい' %>
           </div>
 
           <div class="form-group">
-            <%= f.label :password_confirmation, "パスワード(確認)" %><br />
+            <%= f.label :password_confirmation, "パスワード(確認)" %>
             <%= f.password_field :password_confirmation, autocomplete: "off", class: 'form-control', placeholder: '再度パスワードを入力してください' %>
           </div>
           <%= f.submit "変更", class:'btn btn-success btn-block' %>

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,22 +1,12 @@
 <% provide(:html_title, "パスワード再設定メールの送信") %>
 <div class="row">
   <div class="col-12 col-md-7 offset-md-1 form-area">
-    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post, class: 'form-horizontal'}) do |f| %>
+    <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: {method: :post, class: 'form-horizontal'}, :builder => FormHelper::FormWithErrorMessageBuilder) do |f| %>
       <fieldset>
         <div class="col-md-12">
           <span class="header-text">
             パスワードリセット
           </span>
-          <% if resource.errors.any? %>
-            <div class="form-group">
-              <div class="col-lg-9 col-lg-offset-3 text-danger">
-                <%= "#{resource.errors.count}件のエラーがあります。" %>
-                <% resource.errors.full_messages.each do |msg| %>
-                  <span class="help-block"><%= "・#{msg}" %></span>
-                <% end %>
-              </div>
-            </div>
-          <% end %>
 
           <div class="form-group">
             <label for="user_email" class="control-label">メールアドレス</label>

--- a/app/views/devise/registrations/_error_messages.html.erb
+++ b/app/views/devise/registrations/_error_messages.html.erb
@@ -1,8 +1,0 @@
-<% if (resource.errors.messages.keys & target_field).length > 0 %>
-    <div class="form-group col-md-12">
-        <%= "#{resource.errors.count}件のエラーがあります。" %>
-        <% resource.errors.full_messages.each do |msg| %>
-            <span class="help-block"><%= "・#{msg}" %></span>
-        <% end %>
-    </div>
-<% end %>

--- a/app/views/devise/registrations/_sidebar.html.erb
+++ b/app/views/devise/registrations/_sidebar.html.erb
@@ -1,4 +1,4 @@
 <ul class="list-group bg-white">
-  <%= render :partial => "sidebar_item", :locals => { target_action: "edit", text: "プロフィール", action: :edit } %>
-  <%= render :partial => "sidebar_item", :locals => { target_action: "games", text: "ゲーム一覧", action: :games } %>
+  <%= render :partial => "sidebar_item", :locals => { target_action: ["edit", "update"], text: "プロフィール", action: :edit } %>
+  <%= render :partial => "sidebar_item", :locals => { target_action: ["games"], text: "ゲーム一覧", action: :games } %>
 </ul>

--- a/app/views/devise/registrations/_sidebar_item.html.erb
+++ b/app/views/devise/registrations/_sidebar_item.html.erb
@@ -1,4 +1,4 @@
-<% condition =  controller.action_name == target_action %>
+<% condition = target_action.include?(controller.action_name) %>
 <li class="side-menu-item <% if condition %>selected<% end %>">
     <% if condition %>
         <%= text %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -17,12 +17,11 @@
   </div>
   <div class="col-sm-12 col-md-8 order-md-1">
     <div class="profile-form">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'user_profile_form', method: :put,class: 'form-horizontal' }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'user_profile_form', method: :put,class: 'form-horizontal' }, :builder => FormHelper::FormWithErrorMessageBuilder) do |f| %>
         <fieldset>
           <span class="header-text">
             プロフィール変更
           </span>
-          <%= render partial: "error_messages", locals: { target_field: [:username, :email] } %>
 
           <div class="col-md-12">
             <div class="form-group">
@@ -45,12 +44,11 @@
     </div>
 
     <div class="password-form">
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'user_password_form', method: :put,class: 'form-horizontal' }) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { id: 'user_password_form', method: :put,class: 'form-horizontal' }, :builder => FormHelper::FormWithErrorMessageBuilder) do |f| %>
         <fieldset>
           <span class="header-text">
             パスワード変更
           </span>
-          <%= render partial: "error_messages", locals: { target_field: [:password, :password_confirmation, :current_password] } %>
           <div class="col-md-12">
             <div class="form-group">
               <label for="user_current_password" class="control-label">現在のパスワード</label>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -2,18 +2,8 @@
 <div class="row">
   <div class="col-12 col-sm-12 col-md-8 col-lg-7 offset-lg-1">
     <div>
-      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'form-horizontal'}) do |f| %>
+      <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: {class: 'form-horizontal'}, :builder => FormHelper::FormWithErrorMessageBuilder)  do |f| %>
       <fieldset>
-            <% if resource.errors.any? %>
-                <div class="form-group">
-                  <div class="col-lg-9 col-lg-offset-3 text-danger">
-                    <%= "#{resource.errors.count}件のエラーがあります。" %>
-                    <% resource.errors.full_messages.each do |msg| %>
-                        <span class="help-block"><%= "・#{msg}" %></span>
-                    <% end %>
-                  </div>
-                </div>
-            <% end %>
             <div class="col-md-12 form-area">
               <span class="header-text">
                 新規ユーザー登録

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -5,6 +5,10 @@
   <%= link_to "新規ユーザー登録したい場合", new_registration_path(resource_name) %><br />
 <% end -%>
 
+<%- if devise_mapping.registerable? && controller_name == 'registrations' %>
+  <%= link_to "SNSログインしたい場合", new_session_path(resource_name) %><br />
+<% end -%>
+
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "パスワードを忘れた場合", new_password_path(resource_name) %><br />
 <% end -%>

--- a/app/views/games/_form.html.erb
+++ b/app/views/games/_form.html.erb
@@ -5,22 +5,12 @@
 
   <div class="col-sm-12 col-md-10 offset-md-1 form-area">
     <div>
-      <%= form_with(model: game, local: true, class: 'form-horizontal', id: 'game-form') do |form| %>
+      <%= form_with(model: game, local: true, class: 'form-horizontal', id: 'game-form', :builder => FormHelper::FormWithErrorMessageBuilder) do |form| %>
           <span class="header-text">
             <%= title %>
           </span>
 
           <fieldset>
-            <% if game.errors.any? %>
-              <div class="form-group">
-                <div class="col-lg-9 col-lg-offset-3 text-danger">
-                  <%= "#{game.errors.count}件のエラーがあります。" %>
-                  <% game.errors.full_messages.each do |msg| %>
-                    <span class="help-block"><%= "・#{msg}" %></span>
-                  <% end %>
-                </div>
-              </div>
-            <% end %>
             <div class="row">
               <div class="col-sm-12 col-md-8 order-md-1">
                 <div class="form-group">
@@ -29,7 +19,7 @@
                 </div>
                 <div class="form-group">
                   <label for="game_category" class="control-label">ジャンル <span class="bg-danger p-1 text-white">必須</span></label>
-                  <%= form.select :category_id, @categories.map {|c| [c.name, c.id]}, {include_blank: '選択してください'}, {id: 'game_category', class: 'form-control', "v-model" => "game.category_id"} %>
+                  <%= form.select :category, :category_id, @categories.map {|c| [c.name, c.id]}, {include_blank: '選択してください'}, {id: 'game_category', class: 'form-control', "v-model" => "game.category_id"} %>
                 </div>
                 <div class="form-group">
                   <label for="game_guideline" class="control-label">ガイドライン</label>


### PR DESCRIPTION
Fixes #110

## 変更箇所
* フォーム上部にまとめて表示されていたエラーメッセージを入力フォームの下に表示されるようにしました
* 上記を実現するために form_helper.rb を追加しました
* プロフィール画面でエラー発生時にスタイルが崩れていたのを修正しました
* プロフィール更新後、トップページではなくプロフィール画面に遷移するようにしました
